### PR TITLE
Don't use LazyDFU (it is unsupported for 1.20+)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 //		transitive false
 //	}
 
-	modRuntimeOnly("com.github.astei:lazydfu:master-SNAPSHOT")
+	// modRuntimeOnly("com.github.astei:lazydfu:master-SNAPSHOT")
 
 	testmodImplementation sourceSets.main.output
 }


### PR DESCRIPTION
Hey there! I've been looking into crafting with NBT too and I came across this fork. `runClient` didn't work for me because of LazyDFU. That mod will not continue support from 1.20 up because the vanilla DataFixerUpper has been reworked, rendering the mod redundant. So this removes the mod from `build.gradle`. 

By the way, are you planning on releasing the updated version of the mod on Modrinth? It would be awesome to be able to update it from my launcher instead of having to build it myself. I would be willing to help out too, if you need help with that.